### PR TITLE
added boto3 dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     long_description=open('README.rst').read(),
     install_requires=[
         'awscli>=1.10.14',
-	'boto3>=1.3.1'
+        'boto3>=1.3.1'
     ],
     entry_points={
         'console_scripts': ['awsh = awsh:main']

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,8 @@ setup(
     classifiers=[],
     long_description=open('README.rst').read(),
     install_requires=[
-        'awscli>=1.10.14'
+        'awscli>=1.10.14',
+	'boto3>=1.3.1'
     ],
     entry_points={
         'console_scripts': ['awsh = awsh:main']


### PR DESCRIPTION
on a clean install boto3 is not installed, thus running the tool for the first time lacks this dependency. 
